### PR TITLE
Adding JAWSDB_URL to connection.js

### DIFF
--- a/config/connection.js
+++ b/config/connection.js
@@ -1,15 +1,21 @@
 const Sequelize = require('sequelize');
 require('dotenv').config();
 
-const sequelize = new Sequelize(
-  process.env.DB_NAME,
-  process.env.DB_USER,
-  process.env.DB_PASSWORD,
-  {
-    host: 'localhost',
-    dialect: 'mysql',
-    port: 3306,
-  }
-);
+let sequelize;
+
+if (process.env.JAWSDB_URL) {
+  sequelize = new Sequelize(process.env.JAWSDB_URL);
+} else {
+  sequelize = new Sequelize(
+    process.env.DB_NAME,
+    process.env.DB_USER,
+    process.env.DB_PW,
+    {
+      host: 'localhost',
+      dialect: 'mysql',
+      port: 3306,
+    },
+  );
+}
 
 module.exports = sequelize;


### PR DESCRIPTION
Required for the Heroku and SQL
JAWSDB_URL

https://coding-boot-camp.github.io/full-stack/heroku/deploy-with-heroku-and-mysql